### PR TITLE
Add github ci hook for building Sphinx documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,11 @@ name: Build
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
   push:
+    paths-ignore:
+      - 'doc/**'
     branches:
       - master
       - 'releases/*'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,8 @@ name: Check
 
 on:
   pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 jobs:
   check:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,6 +14,8 @@ name: Doc
 
 on:
   pull_request:
+    paths:
+      - 'docs/**'
 
 jobs:
   docs:

--- a/.github/workflows/sphinx-docs.yml
+++ b/.github/workflows/sphinx-docs.yml
@@ -1,0 +1,33 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: "Build Sphinx Docs"
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'releases/*'
+    tags:
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "doc/"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: sphinx-docs
+        path: doc/_build/html/

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,2 @@
+sphinx-rtd-theme==0.5.0
+recommonmark==0.6.0


### PR DESCRIPTION
# Summary
Add github ci hook for building Sphinx documentation.  This will also create a build artifact containing the generated HTML docs.