### PR TITLE
Cmake Naming of source and Make drive cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,12 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebIn
 
 # Process board config & directory locations #################################
 
+# Deal with the exception
+
+if(NUTTX_BOARD MATCHES "sim")
+	set(NUTTX_BOARD "sim/sim/sim")
+endif()
+
 set(NUTTX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(NUTTX_APPS_SOURCE_DIR "../apps" CACHE FILEPATH "Relative path to apps/ directory")
 get_filename_component(NUTTX_APPS_ABS_DIR ${NUTTX_APPS_SOURCE_DIR} ABSOLUTE BASE_DIR ${NUTTX_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,9 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebIn
 
 # Process board config & directory locations #################################
 
-set(NUTTX_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(NUTTX_APPS_DIR "../apps" CACHE FILEPATH "Relative path to apps/ directory")
-get_filename_component(NUTTX_APPS_ABS_DIR ${NUTTX_APPS_DIR} ABSOLUTE BASE_DIR ${NUTTX_DIR})
+set(NUTTX_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(NUTTX_APPS_SOURCE_DIR "../apps" CACHE FILEPATH "Relative path to apps/ directory")
+get_filename_component(NUTTX_APPS_ABS_DIR ${NUTTX_APPS_SOURCE_DIR} ABSOLUTE BASE_DIR ${NUTTX_SOURCE_DIR})
 
 # Board/config combination
 set(NUTTX_CONFIG "nsh" CACHE STRING "Board confguration")
@@ -36,7 +36,7 @@ if (NOT DEFINED NUTTX_BOARD)
 	message(FATAL_ERROR "Please define a board with NUTTX_BOARD and configuration with NUTTX_CONFIG")
 endif()
 
-set(BOARD_PATH "${NUTTX_DIR}/boards/${NUTTX_BOARD}")
+set(BOARD_PATH "${NUTTX_SOURCE_DIR}/boards/${NUTTX_BOARD}")
 if (NOT EXISTS "${BOARD_PATH}/CMakeLists.txt")
 	message(FATAL_ERROR "No CMakeList.txt found at ${BOARD_PATH} for ${NUTTX_BOARD}")
 endif()
@@ -47,13 +47,14 @@ if (NOT EXISTS "${NUTTX_DEFCONFIG}")
   message(FATAL_ERROR "No config file found at ${NUTTX_DEFCONFIG}")
 endif()
 
-# Generate inital .config ###################################################
+
+################
 # This is needed right before any other configure step so that we can source
 # Kconfig variables into CMake variables
 
 # The following commands need these variables to be passed via environment
 
-set(ENV{APPSDIR} ${NUTTX_APPS_DIR}) # TODO: support not having apps/
+set(ENV{APPSDIR} ${NUTTX_APPS_SOURCE_DIR}) # TODO: support not having apps/
 set(ENV{EXTERNALDIR} dummy) # TODO
 set(ENV{DRIVERS_PLATFORM_DIR} dummy) # TODO
 
@@ -75,7 +76,7 @@ if (NOT EXISTS ${CMAKE_BINARY_DIR}/.config OR
     COMMAND kconfig-conf --olddefconfig Kconfig
     OUTPUT_VARIABLE KCONFIG_OUTPUT
     RESULT_VARIABLE KCONFIG_STATUS
-    WORKING_DIRECTORY ${NUTTX_DIR}
+    WORKING_DIRECTORY ${NUTTX_SOURCE_DIR}
   )
 
   file(RENAME ${CMAKE_BINARY_DIR}/.config.compressed ${CMAKE_BINARY_DIR}/.config)
@@ -94,7 +95,7 @@ if (NOT EXISTS ${CMAKE_BINARY_DIR}/.config OR
 
   message(STATUS "  Board: ${NUTTX_BOARD}")
   message(STATUS "  Config: ${NUTTX_CONFIG}")
-  message(STATUS "  Appdir: ${NUTTX_APPS_DIR}")
+  message(STATUS "  Appdir: ${NUTTX_APPS_SOURCE_DIR}")
 endif()
 
 # Include .cmake files #######################################################
@@ -229,13 +230,13 @@ add_subdirectory(boards)
 
 # Add apps/ to the build (if present)
 
-if(EXISTS ${NUTTX_DIR}/${NUTTX_APPS_DIR}/CMakeLists.txt)
-	add_subdirectory(${NUTTX_APPS_DIR} apps)
+if(EXISTS ${NUTTX_SOURCE_DIR}/${NUTTX_APPS_SOURCE_DIR}/CMakeLists.txt)
+	add_subdirectory(${NUTTX_APPS_SOURCE_DIR} apps)
 	
-	execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink dummy ${NUTTX_APPS_DIR}/platform/board
-                  WORKING_DIRECTORY ${NUTTX_APPS_DIR})
+	execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink dummy ${NUTTX_APPS_SOURCE_DIR}/platform/board
+                  WORKING_DIRECTORY ${NUTTX_APPS_SOURCE_DIR})
 else()
-  message(STATUS "Application directory not found at ${NUTTX_APPS_DIR}, skipping")
+  message(STATUS "Application directory not found at ${NUTTX_APPS_SOURCE_DIR}, skipping")
 endif()
 
 # Same for external/

--- a/Makefile
+++ b/Makefile
@@ -17,31 +17,97 @@
 # under the License.
 #
 ############################################################################
+# Get a list of all config targets boards
 
-# Check if the system has been configured
+ALL_CONFIG_TARGETS := $(shell tools/configure.sh -L | sed 's/:/-/g' | sort)
 
-ifeq ($(wildcard .config),)
-.DEFAULT default:
-	@echo "NuttX has not been configured!"
-	@echo "To configure the project:"
-	@echo "  tools/configure.sh <config>"
-	@echo "For a list of available configurations:"
-	@echo "  tools/configure.sh -L"
-else
-include .config
+NINJA_BIN := ninja
+ifndef NO_NINJA_BUILD
+	NINJA_BUILD := $(shell $(NINJA_BIN) --version 2>/dev/null)
 
-# Build any necessary tools needed early in the build.
-# incdir - Is needed immediately by all Make.defs file.
-
-TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
-DUMMY  := ${shell $(MAKE) -C tools -f Makefile.host incdir \
-          INCDIR="$(TOPDIR)/tools/incdir.sh"}
-
-# Include the correct Makefile for the selected architecture.
-
-ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-include tools/Makefile.win
-else
-include tools/Makefile.unix
+	ifndef NINJA_BUILD
+		NINJA_BIN := ninja-build
+		NINJA_BUILD := $(shell $(NINJA_BIN) --version 2>/dev/null)
+	endif
 endif
+
+ifdef NINJA_BUILD
+	NUTTX_CMAKE_GENERATOR := Ninja
+	NUTTX_MAKE := $(NINJA_BIN)
+
+	ifdef VERBOSE
+		NUTTX_MAKE_ARGS := -v
+	else
+		NUTTX_MAKE_ARGS :=
+	endif
+
+	# Only override ninja default if -j is set.
+	ifneq ($(j),)
+		NUTTX_MAKE_ARGS := $(NUTTX_MAKE_ARGS) -j$(j)
+	endif
+else
+	ifdef SYSTEMROOT
+		# Windows
+		NUTTX_CMAKE_GENERATOR := "MSYS\ Makefiles"
+	else
+		NUTTX_CMAKE_GENERATOR := "Unix\ Makefiles"
+	endif
+
+	# For non-ninja builds we default to -j4
+	j := $(or $(j),4)
+	NUTTX_MAKE = $(MAKE)
+	NUTTX_MAKE_ARGS = -j$(j) --no-print-directory
 endif
+
+SRC_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
+NUTTX_BUILD_ROOT=$(SRC_DIR)/build
+# --------------------------------------------------------------------
+# describe how to build a cmake config
+define cmake-build
+	@$(eval BUILD_DIR = "$(NUTTX_BUILD_ROOT)/$(1)")
+	@# check if the desired cmake configuration matches the cache then CMAKE_CACHE_CHECK stays empty
+	@$(call cmake-cache-check)
+	@# make sure to start from scratch when switching from GNU Make to Ninja
+	@if [ $(NUTTX_CMAKE_GENERATOR) = "Ninja" ] && [ -e $(BUILD_DIR)/Makefile ]; then rm -rf $(BUILD_DIR); fi
+	@# make sure to start from scratch if ninja build file is missing
+	@if [ $(NUTTX_CMAKE_GENERATOR) = "Ninja" ] && [ ! -f $(BUILD_DIR)/build.ninja ]; then rm -rf $(BUILD_DIR); fi
+	@# only excplicitly configure the first build, if cache file already exists the makefile will rerun cmake automatically if necessary
+	@if [ ! -e $(BUILD_DIR)/CMakeCache.txt ] || [ $(CMAKE_CACHE_CHECK) ]; then \
+		mkdir -p $(BUILD_DIR) \
+		&& cd $(BUILD_DIR) \
+		&& echo "cmake -S "$(SRC_DIR)" -B $(BUILD_DIR) -G"$(NUTTX_CMAKE_GENERATOR)" $(CMAKE_ARGS)" \
+		&& cmake -S "$(SRC_DIR)" -B $(BUILD_DIR) -G"$(NUTTX_CMAKE_GENERATOR)" $(CMAKE_ARGS) \
+		|| (rm -rf $(BUILD_DIR)); \
+	fi
+	@# run the build for the specified target
+	@cmake --build $(BUILD_DIR) -- $(NUTTX_MAKE_ARGS) $(ARGS)
+endef
+
+
+# check if the options we want to build with in CMAKE_ARGS match the ones which are already configured in the cache inside BUILD_DIR
+define cmake-cache-check
+	@# change to build folder which fails if it doesn't exist and CACHED_CMAKE_OPTIONS stays empty
+	@# fetch all previously configured and cached options from the build folder and transform them into the OPTION=VALUE format without type (e.g. :BOOL)
+	@$(eval CACHED_CMAKE_OPTIONS = $(shell cd $(BUILD_DIR) 2>/dev/null && cmake -L 2>/dev/null | sed -n 's|\([^[:blank:]]*\):[^[:blank:]]*\(=[^[:blank:]]*\)|\1\2|gp' ))
+	@# transform the options in CMAKE_ARGS into the OPTION=VALUE format without -D
+	@$(eval DESIRED_CMAKE_OPTIONS = $(shell echo $(CMAKE_ARGS) | sed -n 's|-D\([^[:blank:]]*=[^[:blank:]]*\)|\1|gp' ))
+	@# find each currently desired option in the already cached ones making sure the complete configured string value is the same
+	@$(eval VERIFIED_CMAKE_OPTIONS = $(foreach option,$(DESIRED_CMAKE_OPTIONS),$(strip $(findstring $(option)$(space),$(CACHED_CMAKE_OPTIONS)))))
+	@# if the complete list of desired options is found in the list of verified options we don't need to reconfigure and CMAKE_CACHE_CHECK stays empty
+	@$(eval CMAKE_CACHE_CHECK = $(if $(findstring $(DESIRED_CMAKE_OPTIONS),$(VERIFIED_CMAKE_OPTIONS)),,y))
+endef
+
+# All targets.
+help:
+	@echo "make <target> where target is one targes list with tools/configure.sh -L (use a dash as the seperator)"
+
+$(ALL_CONFIG_TARGETS):
+	@$(eval NUTTX_TARGET = $@)
+	$(eval NUTTX_BOARD = $(firstword $(subst -, ,$(NUTTX_TARGET))))
+	$(eval NUTTX_CONFIG = $(lastword $(subst -, ,$(NUTTX_TARGET))))
+	@$(eval CMAKE_ARGS += "-DNUTTX_BOARD:STRING=$(NUTTX_BOARD) -DNUTTX_CONFIG:string=$(NUTTX_CONFIG)" )
+	@$(call cmake-build,$(NUTTX_TARGET))
+
+#todo fix the tools.
+clean:
+	rm -fr $(NUTTX_BUILD_ROOT)

--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -232,5 +232,5 @@ target_sources(nuttx PRIVATE ${HOSTSRCS})
 target_link_libraries(nuttx PUBLIC ${STDLIBS})
 target_compile_definitions(nuttx PRIVATE ${HOST_DEFINITIONS})
 
-configure_file(${NUTTX_DIR}/include/nuttx/fs/hostfs.h ${CMAKE_BINARY_DIR}/include/host/hostfs.h COPYONLY)
+configure_file(${NUTTX_SOURCE_DIR}/include/nuttx/fs/hostfs.h ${CMAKE_BINARY_DIR}/include/host/hostfs.h COPYONLY)
 target_include_directories(nuttx PRIVATE ${CMAKE_BINARY_DIR}/include/host)

--- a/arch/sim/src/sim/up_hostfs.c
+++ b/arch/sim/src/sim/up_hostfs.c
@@ -343,7 +343,7 @@ void *host_opendir(const char *name)
  * Name: host_readdir
  ****************************************************************************/
 
-int host_readdir(void *dirp, struct nuttx_dirent_s *entry)
+int host_readdir(void *dirp, struct NUTTX_SOURCE_DIRent_s *entry)
 {
   struct dirent *ent;
 

--- a/cmake/custom_commands.cmake
+++ b/cmake/custom_commands.cmake
@@ -3,7 +3,7 @@
 add_custom_command(
 	OUTPUT ${CMAKE_BINARY_DIR}/.version
 	COMMAND tools/version.sh -b ${CONFIG_VERSION_BUILD} -v ${CONFIG_VERSION_STRING}  ${CMAKE_BINARY_DIR}/.version
-	WORKING_DIRECTORY ${NUTTX_DIR}
+	WORKING_DIRECTORY ${NUTTX_SOURCE_DIR}
   DEPENDS ${CMAKE_BINARY_DIR}/.config
 )
 
@@ -23,7 +23,7 @@ add_custom_command(
 		nuttx_host_tools
 		${CMAKE_BINARY_DIR}/.config
 		${CMAKE_BINARY_DIR}/.version
-	WORKING_DIRECTORY ${NUTTX_DIR}
+	WORKING_DIRECTORY ${NUTTX_SOURCE_DIR}
 )
 
 # Setup symbolic link generation 
@@ -37,10 +37,10 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/include_nuttx
   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/include_apps
 
-	COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_DIR}/arch/${CONFIG_ARCH}/include ${CMAKE_BINARY_DIR}/include/arch # include/arch
-	COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_DIR}/boards/${NUTTX_BOARD}/include ${CMAKE_BINARY_DIR}/include_arch/arch/board	# include/arch/board
-	COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_DIR}/arch/${CONFIG_ARCH}/include/${CONFIG_ARCH_CHIP} ${CMAKE_BINARY_DIR}/include_arch/arch/chip	# include/arch/chip
-  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_DIR}/include/nuttx ${CMAKE_BINARY_DIR}/include_nuttx/nuttx # include/nuttx
+	COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_SOURCE_DIR}/arch/${CONFIG_ARCH}/include ${CMAKE_BINARY_DIR}/include/arch # include/arch
+	COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_SOURCE_DIR}/boards/${NUTTX_BOARD}/include ${CMAKE_BINARY_DIR}/include_arch/arch/board	# include/arch/board
+	COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_SOURCE_DIR}/arch/${CONFIG_ARCH}/include/${CONFIG_ARCH_CHIP} ${CMAKE_BINARY_DIR}/include_arch/arch/chip	# include/arch/chip
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_SOURCE_DIR}/include/nuttx ${CMAKE_BINARY_DIR}/include_nuttx/nuttx # include/nuttx
 
 	COMMAND ${CMAKE_COMMAND} -E touch nuttx_symlinks.stamp
 	DEPENDS
@@ -56,7 +56,7 @@ add_custom_command(
 
 add_custom_command(
   OUTPUT include/stdarg.h
-  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_DIR}/include/nuttx/lib/stdarg.h ${CMAKE_BINARY_DIR}/include/stdarg.h
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_SOURCE_DIR}/include/nuttx/lib/stdarg.h ${CMAKE_BINARY_DIR}/include/stdarg.h
 )
 
 # Target used to copy include/nuttx/lib/math.h.  If CONFIG_ARCH_MATH_H is
@@ -84,7 +84,7 @@ endif()
 
 add_custom_command(
   OUTPUT include/math.h
-  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_DIR}/include/nuttx/lib/math.h ${CMAKE_BINARY_DIR}/include/math.h
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_SOURCE_DIR}/include/nuttx/lib/math.h ${CMAKE_BINARY_DIR}/include/math.h
 )
 
 # The float.h header file defines the properties of your floating point
@@ -95,7 +95,7 @@ add_custom_command(
 
 add_custom_command(
   OUTPUT include/float.h
-  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_DIR}/include/nuttx/lib/float.h ${CMAKE_BINARY_DIR}/include/float.h
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_SOURCE_DIR}/include/nuttx/lib/float.h ${CMAKE_BINARY_DIR}/include/float.h
 )
 
 # Target used to copy include/nuttx/lib/setjmp.h.  If CONFIG_ARCH_SETJMP_H is
@@ -105,7 +105,7 @@ add_custom_command(
 
 add_custom_command(
   OUTPUT include/setjmp.h
-  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_DIR}/include/nuttx/lib/setjmp.h ${CMAKE_BINARY_DIR}/include/setjmp.h
+  COMMAND ${CMAKE_COMMAND} -E create_symlink ${NUTTX_SOURCE_DIR}/include/nuttx/lib/setjmp.h ${CMAKE_BINARY_DIR}/include/setjmp.h
 )
 
 # Add final context target that ties together all of the above

--- a/cmake/menuconfig.cmake
+++ b/cmake/menuconfig.cmake
@@ -3,12 +3,12 @@
 
 add_custom_target(menuconfig
   COMMAND
-		KCONFIG_CONFIG=${CMAKE_BINARY_DIR}/.config EXTERNALDIR=dummy DRIVERS_PLATFORM_DIR=dummy APPSDIR=${NUTTX_APPS_DIR} kconfig-mconf Kconfig
+		KCONFIG_CONFIG=${CMAKE_BINARY_DIR}/.config EXTERNALDIR=dummy DRIVERS_PLATFORM_DIR=dummy APPSDIR=${NUTTX_APPS_SOURCE_DIR} kconfig-mconf Kconfig
 	COMMAND
 		${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/include/nuttx/config.h	# invalidate existing config
   COMMAND
     ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
-	WORKING_DIRECTORY ${NUTTX_DIR}
+	WORKING_DIRECTORY ${NUTTX_SOURCE_DIR}
 	USES_TERMINAL
 )
 
@@ -16,12 +16,12 @@ add_custom_target(menuconfig
 
 add_custom_target(qconfig
   COMMAND
-		KCONFIG_CONFIG=${CMAKE_BINARY_DIR}/.config EXTERNALDIR=dummy DRIVERS_PLATFORM_DIR=dummy APPSDIR=${NUTTX_APPS_DIR} kconfig-qconf Kconfig
+		KCONFIG_CONFIG=${CMAKE_BINARY_DIR}/.config EXTERNALDIR=dummy DRIVERS_PLATFORM_DIR=dummy APPSDIR=${NUTTX_APPS_SOURCE_DIR} kconfig-qconf Kconfig
 	COMMAND
 		${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/include/nuttx/config.h	# invalidate existing config
   COMMAND
     ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
-	WORKING_DIRECTORY ${NUTTX_DIR}
+	WORKING_DIRECTORY ${NUTTX_SOURCE_DIR}
 	USES_TERMINAL
 )
 
@@ -31,7 +31,7 @@ add_custom_target(qconfig
 #	#COMMAND
 #	#	${CMAKE_COMMAND} -E copy_if_different ${CMAKE_BINARY_DIR}/.config .config
 #	COMMAND
-#		KCONFIG_CONFIG=${CMAKE_BINARY_DIR}/.config APPSDIR=${NUTTX_APPS_DIR} kconfig-conf --savedefconfig defconfig.tmp Kconfig
+#		KCONFIG_CONFIG=${CMAKE_BINARY_DIR}/.config APPSDIR=${NUTTX_APPS_SOURCE_DIR} kconfig-conf --savedefconfig defconfig.tmp Kconfig
 #	COMMAND
 #		sed -i -e "/CONFIG_APPS_DIR=/d" defconfig.tmp			# remove CONFIG_APPS_DIR
 #	COMMAND
@@ -53,16 +53,16 @@ add_custom_target(qconfig
 #	DEPENDS
 #		${CMAKE_BINARY_DIR}/.config
 #	COMMENT "Compressing .config and saving back to ${NUTTX_DEFCONFIG}"
-#	WORKING_DIRECTORY ${NUTTX_DIR}
+#	WORKING_DIRECTORY ${NUTTX_SOURCE_DIR}
 #)
 
 # utility target to restore .config from board's defconfig
 add_custom_target(resetconfig
   COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DEFCONFIG} ${CMAKE_BINARY_DIR}/.config
-  COMMAND KCONFIG_CONFIG=${CMAKE_BINARY_DIR}/.config EXTERNALDIR=dummy DRIVERS_PLATFORM_DIR=dummy APPSDIR=${NUTTX_APPS_DIR} kconfig-conf --olddefconfig Kconfig
+  COMMAND KCONFIG_CONFIG=${CMAKE_BINARY_DIR}/.config EXTERNALDIR=dummy DRIVERS_PLATFORM_DIR=dummy APPSDIR=${NUTTX_APPS_SOURCE_DIR} kconfig-conf --olddefconfig Kconfig
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/.config ${CMAKE_BINARY_DIR}/.config.orig
   COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_PARENT_LIST_FILE}
-  WORKING_DIRECTORY ${NUTTX_DIR}
+  WORKING_DIRECTORY ${NUTTX_SOURCE_DIR}
 )
 
 add_custom_target(diffconfig

--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -123,7 +123,7 @@ struct nuttx_timespec
 
 /* These must exactly match the definition from include/dirent.h: */
 
-struct nuttx_dirent_s
+struct NUTTX_SOURCE_DIRent_s
 {
   uint8_t      d_type;                     /* type of file */
   char         d_name[NUTTX_NAME_MAX + 1]; /* filename */
@@ -180,7 +180,7 @@ int           host_dup(int fd);
 int           host_fstat(int fd, struct nuttx_stat_s *buf);
 int           host_ftruncate(int fd, off_t length);
 void         *host_opendir(const char *name);
-int           host_readdir(void *dirp, struct nuttx_dirent_s *entry);
+int           host_readdir(void *dirp, struct NUTTX_SOURCE_DIRent_s *entry);
 void          host_rewinddir(void *dirp);
 int           host_closedir(void *dirp);
 int           host_statfs(const char *path, struct nuttx_statfs_s *buf);

--- a/libs/libnx/nxfonts/CMakeLists.txt
+++ b/libs/libnx/nxfonts/CMakeLists.txt
@@ -8,7 +8,7 @@ endfunction()
 if (CONFIG_NXFONTS)
   nuttx_add_aux_library(nxfonts)
   target_include_directories(nxfonts PRIVATE ${CMAKE_CURRENT_LIST_DIR})
-  target_include_directories(nxfonts PRIVATE ${NUTTX_DIR}/libs/libnx)
+  target_include_directories(nxfonts PRIVATE ${NUTTX_SOURCE_DIR}/libs/libnx)
 
   # Font conversion operations ###############################################
 

--- a/libs/libxx/CMakeLists.txt
+++ b/libs/libxx/CMakeLists.txt
@@ -48,6 +48,6 @@ else()
 endif()
 
 #include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-#include_directories(SYSTEM ${NUTTX_DIR}/include/cxx)
+#include_directories(SYSTEM ${NUTTX_SOURCE_DIR}/include/cxx)
 
 

--- a/libs/libxx/cxx.cmake
+++ b/libs/libxx/cxx.cmake
@@ -36,4 +36,4 @@ target_sources(xx PRIVATE
 set_property(SOURCE libxx_new.cxx APPEND PROPERTY COMPILE_OPTIONS -Wno-missing-exception-spec)
 set_property(SOURCE libxx_newa.cxx APPEND PROPERTY COMPILE_OPTIONS -Wno-missing-exception-spec)
 
-target_include_directories(xx PUBLIC ${NUTTX_DIR}/include/cxx)
+target_include_directories(xx PUBLIC ${NUTTX_SOURCE_DIR}/include/cxx)


### PR DESCRIPTION
## Summary

1) Made the naming explicit for SOURCE  - Over time this is very helpful as things grow
2) Driving cmake from Make (This needs more work) but make this smoooooth for make file folks.... 

 I got to `cmake -B build/sim/nsh -DNUTTX_BOARD:STRING=sim/sim/sim -DNUTTX_CONFIG:string=nsh` After figuring the constructs inplace.

Now you can just type `make sim-nsh" (Tab key works sim-n<tab>"

## Impact

Can fill you disk faster with less typing :)

## Testing
Linux Ubuntu 20.04.2 LTS

